### PR TITLE
Prepare relay for public release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wechat-relay-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Use Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit dependencies
+        run: npm run audit:dependencies
+
+      - name: Run verification
+        run: npm run check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+## Before opening a change
+
+- Use only synthetic credentials, account identifiers, article bodies, media
+  identifiers, server addresses, logs, and database fixtures.
+- Never commit a populated environment file, WeChat credential, relay token,
+  request or response body, unpublished article, server configuration, or
+  SQLite runtime state.
+- Preserve loopback binding, exact upstream route allowlists, bounded requests,
+  authenticated readiness, idempotency fail-closed behavior, redacted logs,
+  and the draft-only boundary.
+
+## Development
+
+Use a supported Node.js major and the exact lockfile:
+
+```bash
+npm ci
+npm run audit:dependencies
+npm run check
+```
+
+## Contribution license
+
+By submitting a contribution, you license it under
+`AGPL-3.0-or-later` and confirm that you have the right to submit it under
+those terms. Explain user-visible behavior, trust-boundary changes, deployment
+or rollback impact, and the tests used to validate the change.

--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,3 @@
-wechat-relay
-Copyright (C) 2026 wechat-relay contributors
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version. See the full text below.
-
-================================================================================
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,14 @@
+# wechat-relay notice
+
+wechat-relay
+
+Copyright (C) 2026 wechat-relay contributors
+
+This program is licensed under the GNU Affero General Public License, version 3
+or any later version (`AGPL-3.0-or-later`). The complete, unmodified license
+text is in [`LICENSE`](LICENSE).
+
+Commercial use is permitted under the AGPL. Commercial deployment,
+customization, training, and technical support may be arranged separately with
+the repository maintainer; those services do not replace or restrict the AGPL
+license granted for the software.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # wechat-relay
 
-`wechat-relay` is a small, private relay for four WeChat Official Account draft APIs. It exists for one narrow deployment problem: the Official Account allowlist sees the relay server's fixed outbound IPv4 instead of a changing client address.
+`wechat-relay` is a small, public, self-hosted relay for four WeChat Official Account draft APIs. It exists for one narrow deployment problem: the Official Account allowlist sees the relay server's fixed outbound IPv4 instead of a changing client address.
+
+Commercial use is permitted, but users must comply with
+`AGPL-3.0-or-later`. For commercial deployment, customization, training, or
+technical support, contact the repository maintainer.
+
+> 商业使用：允许，但必须遵守 AGPL-3.0-or-later。
+>
+> 商业部署、定制、培训与技术支持：可联系维护者。
 
 The relay creates or reads drafts only through the four documented compatibility routes. It does not automate the WeChat client, open the Official Account web console, mass-send, publish, or provide a generic WeChat API proxy.
 
@@ -55,8 +63,15 @@ It documents two supported routes:
 
 There is deliberately no one-command installer. Credential creation, network exposure, WeChat allowlisting, and service activation remain explicit operator decisions.
 
+## Related repository
+
+- [Ailu](https://github.com/mcncarl/ailu) is the public Obsidian client that
+  uses this relay for explicit, draft-only WeChat Official Account uploads.
+  Ailu and this service are installed and configured separately.
+
 ## License
 
 Copyright 2026 wechat-relay contributors.
 
 Licensed under the GNU Affero General Public License, version 3 or any later version (`AGPL-3.0-or-later`). See [LICENSE](LICENSE).
+The project copyright and modification notice is preserved in [NOTICE.md](NOTICE.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,15 @@
 
 ## Supported version
 
-Only the latest reviewed revision on the private `main` branch is supported. Deploy by immutable revision and keep `package-lock.json` with it.
+Security fixes target the latest published release and the current `main`
+branch. Deploy an immutable tag or commit and keep its matching
+`package-lock.json`.
 
 ## Reporting a vulnerability
 
-Use a private GitHub Security Advisory for this repository. Do not open a public issue containing a credential, request body, media identifier, unpublished article, server address, or exploit details.
+Use [GitHub private vulnerability reporting](https://github.com/mcncarl/wechat-relay/security/advisories/new).
+Do not open a public issue containing a credential, request body, media
+identifier, unpublished article, server address, or exploit details.
 
 Include the affected revision, route, preconditions, impact, and a minimal redacted reproduction. Never use a real Official Account credential or create a real draft while demonstrating a report.
 

--- a/deploy/wechat-relay.service
+++ b/deploy/wechat-relay.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Private WeChat Official Account draft relay
+Description=Self-hosted WeChat Official Account draft relay
 Documentation=https://github.com/mcncarl/wechat-relay
 After=network-online.target
 Wants=network-online.target

--- a/docs/DEPLOY_UBUNTU_24_04.md
+++ b/docs/DEPLOY_UBUNTU_24_04.md
@@ -6,11 +6,17 @@ This is intentionally a manual procedure. Read every command, substitute only op
 
 Use an operator-controlled Ubuntu 24.04 server with a stable outbound IPv4. Hong Kong is the preferred region when it provides the required IPv4 and acceptable access to `api.weixin.qq.com`; it is not a substitute for testing connectivity.
 
-Install one supported Node.js LTS major (20.x, 22.x, or 24.x) from an official distribution channel, then verify the major before installing dependencies:
+Install one supported Node.js LTS major (20.x, 22.x, or 24.x) from an official
+system-level distribution channel. The provided systemd unit executes
+`/usr/bin/node`, so that exact path must exist and npm must be visible to the
+dedicated build account. Verify the paths and major before installing
+dependencies:
 
 ```bash
-node --version
-npm --version
+test "$(command -v node)" = "/usr/bin/node"
+test "$(command -v npm)" = "/usr/bin/npm"
+/usr/bin/node --version
+/usr/bin/npm --version
 ```
 
 Never reuse `node_modules` across Node major versions. `better-sqlite3` is a native addon and must be installed for the selected LTS runtime.
@@ -27,14 +33,21 @@ Create a dedicated, non-login build account. It may write the source tree only w
 ```bash
 sudo useradd --system --create-home --home-dir /var/lib/wechat-relay-build --shell /usr/sbin/nologin wechat-relay-build
 sudo install -d -m 0755 -o wechat-relay-build -g wechat-relay-build /opt/wechat-relay
-sudo -H -u wechat-relay-build git clone https://github.com/mcncarl/wechat-relay.git /opt/wechat-relay
+sudo -H -u wechat-relay-build /usr/bin/node --version
+sudo -H -u wechat-relay-build /usr/bin/npm --version
+sudo -H -u wechat-relay-build git clone --branch 0.1.0 --depth 1 https://github.com/mcncarl/wechat-relay.git /opt/wechat-relay
 cd /opt/wechat-relay
-sudo -H -u wechat-relay-build npm ci --omit=dev
+sudo -H -u wechat-relay-build /usr/bin/npm ci --omit=dev
 sudo chown -R root:root /opt/wechat-relay
 sudo chmod -R u=rwX,go=rX /opt/wechat-relay
 ```
 
-Use a repository-scoped, read-only deploy credential for the build account and keep it out of shell arguments and Git configuration inside the checkout. Review `package-lock.json` before installation. Dependency lifecycle scripts never run as root; after installation, the root-owned checkout is no longer writable by the build account. The systemd service still runs as a separate `DynamicUser` with access only to its private state directory.
+The public repository can be cloned anonymously; do not put a GitHub token or
+Deploy Key in the clone URL or server checkout. Review `package-lock.json`
+before installation. Dependency lifecycle scripts never run as root; after
+installation, the root-owned checkout is no longer writable by the build
+account. The systemd service still runs as a separate `DynamicUser` with access
+only to its private state directory.
 
 Do not copy local test results, launchd property lists, old server configuration, or an existing `.env` into this directory.
 
@@ -160,7 +173,7 @@ sudo systemctl stop wechat-relay.service
 sudo chown -R wechat-relay-build:wechat-relay-build /opt/wechat-relay
 sudo -H -u wechat-relay-build git -C /opt/wechat-relay fetch --all --prune
 sudo -H -u wechat-relay-build git -C /opt/wechat-relay checkout <reviewed-revision>
-sudo -H -u wechat-relay-build npm ci --omit=dev --prefix /opt/wechat-relay
+sudo -H -u wechat-relay-build /usr/bin/npm ci --omit=dev --prefix /opt/wechat-relay
 sudo chown -R root:root /opt/wechat-relay
 sudo chmod -R u=rwX,go=rX /opt/wechat-relay
 sudo systemctl start wechat-relay.service

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "type": "module",
   "private": true,
   "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcncarl/wechat-relay.git"
+  },
+  "homepage": "https://github.com/mcncarl/wechat-relay#readme",
+  "bugs": {
+    "url": "https://github.com/mcncarl/wechat-relay/issues"
+  },
   "engines": {
     "node": "20.x || 22.x || 24.x"
   },
@@ -13,7 +21,9 @@
     "test": "node --test",
     "lint": "eslint .",
     "syntax": "node --check src/auth.js && node --check src/body.js && node --check src/config.js && node --check src/errors.js && node --check src/idempotency-store.js && node --check src/index.js && node --check src/logger.js && node --check src/rate-limit.js && node --check src/routes.js && node --check src/server.js && node --check src/wechat-client.js && node --check scripts/secret-scan.mjs",
-    "secret-scan": "node scripts/secret-scan.mjs"
+    "secret-scan": "node scripts/secret-scan.mjs",
+    "audit:dependencies": "npm audit --audit-level=low",
+    "check": "npm test && npm run lint && npm run syntax && npm run secret-scan"
   },
   "dependencies": {
     "better-sqlite3": "12.4.1"

--- a/test/static-contract.test.js
+++ b/test/static-contract.test.js
@@ -13,7 +13,11 @@ test("package is private, AGPL, and limited to verified Node LTS lines", () => {
   assert.equal(pkg.private, true);
   assert.equal(pkg.license, "AGPL-3.0-or-later");
   assert.equal(pkg.engines.node, "20.x || 22.x || 24.x");
-  assert.match(text("LICENSE"), /GNU AFFERO GENERAL PUBLIC LICENSE\s+Version 3/iu);
+  assert.match(text("LICENSE").trimStart(), /^GNU AFFERO GENERAL PUBLIC LICENSE\s+Version 3/iu);
+  assert.ok(text("NOTICE.md").includes("Copyright (C) 2026 wechat-relay contributors"));
+  assert.ok(text("README.md").includes("Commercial use is permitted"));
+  assert.ok(text("README.md").includes("commercial deployment, customization, training, or"));
+  assert.ok(text("README.md").includes("商业使用：允许，但必须遵守 AGPL-3.0-or-later"));
 });
 
 test("environment example contains keys but no values", () => {
@@ -47,8 +51,11 @@ test("systemd unit keeps Node on loopback with a private writable state director
 
 test("manual deployment documents exactly the two approved edge routes", () => {
   const guide = text("docs/DEPLOY_UBUNTU_24_04.md");
-  assert.match(guide, /sudo -H -u wechat-relay-build npm ci --omit=dev/u);
+  assert.match(guide, /sudo -H -u wechat-relay-build \/usr\/bin\/npm ci --omit=dev/u);
   assert.doesNotMatch(guide, /sudo\s+npm\s+(?:ci|install|rebuild)/u);
+  assert.ok(guide.includes("git clone --branch 0.1.0 --depth 1 https://github.com/mcncarl/wechat-relay.git"));
+  assert.ok(guide.includes("public repository can be cloned anonymously"));
+  assert.ok(guide.includes('test "$(command -v node)" = "/usr/bin/node"'));
   assert.ok(guide.includes("lifecycle scripts never run as root"));
   assert.ok(guide.includes("Tailscale Serve"));
   assert.ok(guide.includes("operator domain plus Caddy"));
@@ -75,4 +82,5 @@ test("protocol and threat model preserve the narrow four-route boundary", () => 
   assert.match(threatModel, /^Version: uncommitted-snapshot-sha256:[0-9a-f]{64}$/mu);
   assert.equal(/^Version: snapshot-pending$/mu.test(threatModel), false);
   assert.ok(text("SECURITY.md").includes("Access tokens never leave process memory"));
+  assert.ok(text("SECURITY.md").includes("/security/advisories/new"));
 });


### PR DESCRIPTION
## What changed

- replace private-repository wording with public anonymous deployment instructions
- restore a canonical AGPL license file and preserve project notice separately
- add the requested commercial-use and commercial-support wording
- add a private vulnerability reporting route and contribution licensing terms
- add pinned CI and Dependabot configuration
- align Ubuntu deployment with the systemd /usr/bin/node contract and fixed 0.1.0 tag

## Validation

- npm ci and dependency audit passed with 0 vulnerabilities
- 38 tests passed
- lint, syntax validation, and repository secret scan passed
- no real WeChat credential or external draft operation was used